### PR TITLE
Bugfix - Damage table is full of 0 when seconds threshold reaches limit

### DIFF
--- a/damage-tracker.lua
+++ b/damage-tracker.lua
@@ -96,9 +96,13 @@ function periodicRegisterDamage()
       table.remove(damageDone[name]) -- removes the last element, because its the oldest
     end
 
+    if damage == 0 then
+      table.remove(damageDone[name])
+    else
+      table.insert(damageDone[name], 1, damage) -- add the damage always on the start of the table, so it will always pop the most oldest value
+      damageDoneThisSecond[name] = 0;
+    end
 
-    table.insert(damageDone[name], 1, damage) -- add the damage always on the start of the table, so it will always pop the most oldest value
-    damageDoneThisSecond[name] = 0;
   end
 end
 


### PR DESCRIPTION
The bug makes the DPS calculation prone to erroneous output.

The damage calculations is made within a table, which the key is the character name, and the value is another table (I'll name it DT) with the damage values in each position, from newest to oldest. Each item in DT corresponds to a second of damage output from the character. The DPS calculation is done with the average of the damage done (value sum / DT size).

When the character stops output damage, the DT will be filled with 0, and until all the values of DT be greater than 0, the calculation will be erroneous, since we will have some "seconds wasted" with 0 damage output.

The solution is to, if the character has a damageThisSecond of 0, we delete the least damage, reducin the size of the DT until it reaches to 0, and we start over again.
  